### PR TITLE
Support universal binary on MacOS

### DIFF
--- a/src/edge_api.ts
+++ b/src/edge_api.ts
@@ -74,7 +74,9 @@ export class EdgeUpdatesProduct {
     const platformValue = EdgeUpdatesProduct.PlatformValues[os];
     const archValue = EdgeUpdatesProduct.ArchValues[arch];
     const release = this.json.Releases.find(
-      (r) => r.Platform === platformValue && r.Architecture === archValue
+      (r) =>
+        r.Platform === platformValue &&
+        (r.Architecture == "universal" || r.Architecture === archValue)
     );
     if (release) {
       return new EdgeUpdatesProductRelease(release);


### PR DESCRIPTION
Microsoft Edge for only Intel-based macOS is no longer available.  CI failed with the following message:
> Error: Unsupported platform: darwin amd64

Now the setup-edge on macOS uses an "universal" binary which  supports both Apple silicon and Intel-based Mac.   