### PR TITLE
Do not wait installer

### DIFF
--- a/src/installer_windows.ts
+++ b/src/installer_windows.ts
@@ -1,5 +1,6 @@
 import { Installer, InstallResult, DownloadResult } from "./installer";
 import { Platform } from "./platform";
+import { waitInstall } from "./watch";
 import * as versions from "./params";
 import path from "path";
 import os from "os";
@@ -42,7 +43,12 @@ export class WindowsInstaller implements Installer {
     version: versions.Version,
     archive: string
   ): Promise<InstallResult> {
-    await exec.exec(archive);
+    // Do not wait for the installer, as an installer for windows requires an
+    // OK prompt on the dialog at the end of the install.
+    await Promise.race([
+      exec.exec(archive),
+      waitInstall(path.join(this.rootDir(version), "msedge.exe"))
+    ]);
 
     return { root: this.rootDir(version), bin: "msedge.exe" };
   }

--- a/src/installer_windows.ts
+++ b/src/installer_windows.ts
@@ -5,6 +5,7 @@ import * as versions from "./params";
 import path from "path";
 import os from "os";
 import fs from "fs";
+import cp from "child_process";
 import * as tc from "@actions/tool-cache";
 import * as io from "@actions/io";
 import * as core from "@actions/core";
@@ -43,12 +44,22 @@ export class WindowsInstaller implements Installer {
     version: versions.Version,
     archive: string
   ): Promise<InstallResult> {
+    // Use a native API to kill the process.
+    const p = cp.spawn(archive);
+    p.stdout.on("data", (data: Buffer) =>
+      process.stdout.write(data.toString())
+    );
+    p.stderr.on("data", (data: Buffer) =>
+      process.stderr.write(data.toString())
+    );
+
     // Do not wait for the installer, as an installer for windows requires an
     // OK prompt on the dialog at the end of the install.
-    await Promise.race([
-      exec.exec(archive),
-      waitInstall(path.join(this.rootDir(version), "msedge.exe"))
-    ]);
+    try {
+      await waitInstall(path.join(this.rootDir(version), "msedge.exe"));
+    } finally {
+      p.kill();
+    }
 
     return { root: this.rootDir(version), bin: "msedge.exe" };
   }

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+
+const sleep = (millis: number) => {
+  return new Promise((resolve) => setTimeout(resolve, millis));
+};
+
+export const waitInstall = (
+  path: string,
+  timeoutSec: number = 10 * 60,
+  checkIntervalSec = 5
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const resetTimers = () => {
+      clearInterval(watchId);
+      clearTimeout(rejectId);
+    };
+
+    const rejectId = setTimeout(() => {
+      clearTimeout(rejectId);
+      resetTimers();
+      reject(`Install timed-out: ${path}`);
+    }, timeoutSec * 1000);
+
+    const watchId = setInterval(() => {
+      fs.access(path, fs.constants.F_OK, (err) => {
+        if (err === null) {
+          // file exists
+          resetTimers();
+          resolve();
+          return
+        }
+
+        if (err.code !== 'ENOENT') {
+          // unexpected error
+          resetTimers();
+          reject(err);
+          return
+        }
+
+        // file not found
+      })
+    }, checkIntervalSec * 1000);
+  });
+};


### PR DESCRIPTION
Recent edge installer for windows requires an interact action to click the "OK" button at the end of install—the script is stuck and timed out on version `beta` or `dev.`  

This change makes the installer wait for the appearance of the installed binary instead of the installer.