### PR TITLE
chore(ci): grouping dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,22 @@ updates:
     commit-message:
       prefix: "fix(deps)"
       prefix-development: 'chore(deps):'
+    groups:
+      actions:
+        patterns:
+          - "@actions/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "@typescript-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "prettier"
+      jest:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "ts-jest"
+          - "@types/jest"


### PR DESCRIPTION
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/