### PR TITLE
fix: support arm64

### DIFF
--- a/src/installer_mac.ts
+++ b/src/installer_mac.ts
@@ -43,7 +43,6 @@ export class MacInstaller implements Installer {
         `Artifact not found of Edge ${version} for platform ${this.platform.os} ${this.platform.arch}`,
       );
     }
-    artifact.Location;
 
     core.info(
       `Acquiring ${version} (${product.ProductVersion}) from ${artifact.Location}`,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -43,6 +43,8 @@ export const getArch = (): Arch => {
       return Arch.I686;
     case "x64":
       return Arch.AMD64;
+    case "arm64":
+      return Arch.ARM64;
   }
   throw new Error(`Unsupported arch: ${arch}`);
 };


### PR DESCRIPTION
GitHub-hosted macOS runner now run on M1 Mac (ARM64) architecture.

Close #481.