### PR TITLE
Update 3rd-party actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: pnpm package
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./dist/
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu, macos, windows]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
       - name: "Install default channel on ${{ matrix.os }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: 'latest'
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          command: manifest
 
       - uses: actions/checkout@v3
         with:
@@ -49,8 +47,5 @@ jobs:
           git push origin latest
           git push origin v$major_version --force
           git push origin v$full_version
-
-          git tag -a $tag_name $GITHUB_SHA -m "Release v$full_version"
-          git push origin $tag_name
 
         if: ${{ steps.release.outputs.release_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
-      "draft": true
+      "bump-patch-for-minor-pre-major": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Update 3rd-pardy actions. In addition, disable creating draft pull request on the release-please. Release please does not pick up the latest release if releases includes draft releases.