### PR TITLE
fix: bump supported node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   edge-path:
     description: 'The installed Edge path.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Bump supported Node.js version to v20.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Close #483 