### PR TITLE
docs: add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Agentic Coding Guide
+
+This file provides guidance for AI coding agents working in this repository.
+
+## Repository Purpose
+
+`setup-edge` is a GitHub Action that installs Microsoft Edge on GitHub Actions runners. It supports `stable`, `beta`, `dev`, and `canary` channels on Windows, macOS, and Linux.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile   # install dependencies
+pnpm lint                        # lint with Biome (CI mode, no auto-fix)
+pnpm lint:fix                    # lint with auto-fix
+pnpm test                        # run all unit tests with Vitest
+pnpm test -- --reporter=verbose  # verbose test output
+npx vitest run __test__/<file>.test.ts  # run a single test file
+pnpm build                       # compile TypeScript → dist/index.js
+pnpm package                     # copy action.yml + README.md into dist/
+```
+
+## Project Layout
+
+```
+src/
+  index.ts              # action entry point: reads inputs, selects installer, sets outputs
+  platform.ts           # OS/arch detection → Platform struct
+  params.ts             # input parsing and validation (edge-version)
+  installer.ts          # Installer interface
+  installer_linux.ts    # Edge installer for Linux (apt-based)
+  installer_mac.ts      # Edge installer for macOS (pkg-based)
+  installer_windows.ts  # Edge installer for Windows (msi/winget-based)
+  edge_api.ts           # client for the Edge update/release API
+  watch.ts              # utilities for polling/watching install state
+__test__/
+  edge_api.test.ts      # tests for Edge API client
+  testdata.json         # JSON fixtures for API responses
+action.yml              # action metadata: inputs, outputs, runs.using: node24
+biome.json              # linter/formatter config
+```
+
+## Architecture
+
+The action detects the current platform and delegates to the appropriate platform-specific installer class. `edge_api.ts` resolves the concrete version number for the requested channel by querying the Microsoft Edge update API.
+
+## Testing
+
+Tests live in `__test__/` and use [Vitest](https://vitest.dev/).
+
+- `testdata.json` provides mock API response fixtures.
+- Tests mock network calls; no real HTTP requests are made.
+
+## Conventions
+
+- **TypeScript strict mode** — all types must be explicit; avoid `any`.
+- **Linter:** Biome — run `pnpm lint` before committing. `useLiteralKeys` and `noUselessElse` rules are disabled.
+- **Formatter:** Biome with space indentation.
+- **Conventional Commits** are required for all commits (`feat:`, `fix:`, `chore:`, etc.).
+- **Never commit `dist/`** — it is built by CI and deployed to the `latest` branch on release.
+- The `action.yml` `main` field points to `index.js` inside `dist/`, not the TypeScript source.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to setup-edge
+
+Thank you for your interest in contributing!
+
+## Development Setup
+
+**Prerequisites:** Node.js ≥ 24, [pnpm](https://pnpm.io/)
+
+```bash
+# Install dependencies
+pnpm install
+```
+
+## Development Workflow
+
+```bash
+# Lint (CI mode, no auto-fix)
+pnpm lint
+
+# Lint with auto-fix
+pnpm lint:fix
+
+# Run unit tests
+pnpm test
+
+# Run tests with verbose output
+pnpm test -- --reporter=verbose
+
+# Run a single test file
+npx vitest run __test__/<file>.test.ts
+
+# Build (compiles TypeScript → dist/index.js via @vercel/ncc)
+pnpm build
+
+# Package (copies action.yml + README.md into dist/)
+pnpm package
+```
+
+## Submitting Changes
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes with tests where applicable.
+3. Run `pnpm lint` and `pnpm test` to verify everything passes.
+4. Open a pull request against `master`.
+
+**Important:** All commit messages must follow [Conventional Commits][] — this is required for the automated release process to correctly determine version bumps and generate changelog entries.
+
+Examples:
+- `fix: resolve Edge path detection on Windows`
+- `feat: add edge-path output`
+- `chore: update dependencies`
+
+## Release Process
+
+Releases are automated with [Release Please](https://github.com/googleapis/release-please):
+
+1. Merge changes to `master` following Conventional Commits.
+2. Release Please opens or updates a release PR with version bumps and changelog updates.
+3. Squash and merge the release PR.
+4. CI builds `dist/`, pushes it to the `latest` branch, and creates signed `vX` and `vX.Y.Z` tags.
+
+> **Note:** Never commit generated `dist/` files to the source branch — they are built and published automatically by CI.
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ steps:
 - `edge-version`: The installed Edge version. Useful when given a latest version.
 - `edge-path`: The installed Edge path.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, workflow, and release process.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

This PR adds two documentation files to help both human contributors and AI coding agents:

- **`CONTRIBUTING.md`** — development setup, workflow commands (`lint`, `test`, `build`, `package`), code style (Biome), PR guidelines, Conventional Commits requirement, and the release process. The README's inline contributing/release section is replaced with a link to this file.
- **`AGENTS.md`** — agentic coding guide covering commands cheatsheet, project layout, architecture overview, testing guidance, and key conventions (never commit `dist/`, strict TypeScript, etc.).