### PR TITLE
fix: support latest Windows and macOS runners

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "ignore": ["package.json", "__test__/*.json"]
+    "ignore": ["package.json", "__test__/*.json", "dist"]
   },
   "linter": {
     "enabled": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ async function run(): Promise<void> {
     const result = await (async () => {
       const installed = await installer.checkInstalled(version);
       if (installed) {
-        core.info(`Edge ${version} is already installed @ ${installed.root}`);
+        const bin = path.join(installed.root, installed.bin);
+        core.info(`Edge ${version} is already installed @ ${bin}`);
         return installed;
       }
 

--- a/src/installer_mac.ts
+++ b/src/installer_mac.ts
@@ -60,20 +60,6 @@ export class MacInstaller implements Installer {
 
     await exec.exec("xar", ["-xf", archive], { cwd: extdir });
 
-    // Log directory tree to diagnose where the .app bundle is located
-    const walk = async (dir: string, depth = 0): Promise<void> => {
-      if (depth > 3) return;
-      for (const e of await fs.promises.readdir(dir)) {
-        core.info(`${"  ".repeat(depth)}${e}`);
-        const full = path.join(dir, e);
-        if ((await fs.promises.stat(full)).isDirectory()) {
-          await walk(full, depth + 1);
-        }
-      }
-    };
-    core.info(`Extracted pkg structure under ${extdir}:`);
-    await walk(extdir);
-
     const pkgdir = (await fs.promises.readdir(extdir)).filter(
       (e) => e.startsWith("MicrosoftEdge") && e.endsWith(".pkg"),
     )[0];
@@ -89,26 +75,18 @@ export class MacInstaller implements Installer {
     await exec.exec("gzip", ["--decompress", "App.gz"], { cwd: pkgroot });
     await exec.exec("cpio", ["--extract", "--file", "App"], { cwd: pkgroot });
 
-    const app = path.join(pkgroot, this.appName(version));
+    // tc.cacheDir copies the *contents* of the source dir into the cache root,
+    // so we wrap the .app inside a subdirectory to preserve the .app name and
+    // extension. Without this, the bundle root in the cache lacks the .app
+    // suffix and Edge refuses to launch (exits with null on macOS 15+).
+    const wrapperDir = path.join(extdir, "wrapper");
+    await fs.promises.mkdir(wrapperDir);
+    await fs.promises.rename(
+      path.join(pkgroot, this.appName(version)),
+      path.join(wrapperDir, this.appName(version)),
+    );
 
-    // Diagnose codesign and quarantine attributes before caching
-    core.info(`App path: ${app}`);
-    core.info(`App exists: ${fs.existsSync(app)}`);
-    await exec.exec("codesign", ["--verify", "--verbose=4", app], {
-      ignoreReturnCode: true,
-    });
-    await exec.exec("xattr", ["-l", app], { ignoreReturnCode: true });
-    await exec.exec("spctl", ["-a", "-v", app], { ignoreReturnCode: true });
-
-    const root = await tc.cacheDir(app, "msedge", version);
-
-    // Diagnose cached binary
-    const cachedBin = path.join(root, this.binPath(version));
-    core.info(`Cached binary: ${cachedBin}`);
-    core.info(`Cached binary exists: ${fs.existsSync(cachedBin)}`);
-    await exec.exec("ls", ["-la", path.dirname(cachedBin)], {
-      ignoreReturnCode: true,
-    });
+    const root = await tc.cacheDir(wrapperDir, "msedge", version);
 
     return { root, bin: this.binPath(version) };
   }
@@ -116,13 +94,13 @@ export class MacInstaller implements Installer {
   private binPath(version: versions.Version): string {
     switch (version) {
       case versions.StableVersion:
-        return "Contents/MacOS/Microsoft Edge";
+        return "Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
       case versions.BetaVersion:
-        return "Contents/MacOS/Microsoft Edge Beta";
+        return "Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta";
       case versions.DevVersion:
-        return "Contents/MacOS/Microsoft Edge Dev";
+        return "Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev";
       case versions.CanaryVersion:
-        return "Contents/MacOS/Microsoft Edge Canary";
+        return "Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary";
     }
   }
 
@@ -142,17 +120,6 @@ export class MacInstaller implements Installer {
   async test(version: versions.Version): Promise<void> {
     const bin = path.basename(this.binPath(version));
     const msedgeBin = await io.which(bin, true);
-    core.info(`Testing binary: ${msedgeBin}`);
-    const output = await exec.getExecOutput(`"${msedgeBin}"`, ["--version"], {
-      ignoreReturnCode: true,
-    });
-    core.info(`stdout: ${output.stdout}`);
-    core.info(`stderr: ${output.stderr}`);
-    core.info(`exit code: ${output.exitCode}`);
-    if (output.exitCode !== 0) {
-      throw new Error(
-        `Edge binary test failed with exit code ${output.exitCode}\nstderr: ${output.stderr}`,
-      );
-    }
+    await exec.exec(`"${msedgeBin}"`, ["--version"]);
   }
 }

--- a/src/installer_mac.ts
+++ b/src/installer_mac.ts
@@ -60,6 +60,20 @@ export class MacInstaller implements Installer {
 
     await exec.exec("xar", ["-xf", archive], { cwd: extdir });
 
+    // Log directory tree to diagnose where the .app bundle is located
+    const walk = async (dir: string, depth = 0): Promise<void> => {
+      if (depth > 3) return;
+      for (const e of await fs.promises.readdir(dir)) {
+        core.info(`${"  ".repeat(depth)}${e}`);
+        const full = path.join(dir, e);
+        if ((await fs.promises.stat(full)).isDirectory()) {
+          await walk(full, depth + 1);
+        }
+      }
+    };
+    core.info(`Extracted pkg structure under ${extdir}:`);
+    await walk(extdir);
+
     const pkgdir = (await fs.promises.readdir(extdir)).filter(
       (e) => e.startsWith("MicrosoftEdge") && e.endsWith(".pkg"),
     )[0];
@@ -76,7 +90,25 @@ export class MacInstaller implements Installer {
     await exec.exec("cpio", ["--extract", "--file", "App"], { cwd: pkgroot });
 
     const app = path.join(pkgroot, this.appName(version));
+
+    // Diagnose codesign and quarantine attributes before caching
+    core.info(`App path: ${app}`);
+    core.info(`App exists: ${fs.existsSync(app)}`);
+    await exec.exec("codesign", ["--verify", "--verbose=4", app], {
+      ignoreReturnCode: true,
+    });
+    await exec.exec("xattr", ["-l", app], { ignoreReturnCode: true });
+    await exec.exec("spctl", ["-a", "-v", app], { ignoreReturnCode: true });
+
     const root = await tc.cacheDir(app, "msedge", version);
+
+    // Diagnose cached binary
+    const cachedBin = path.join(root, this.binPath(version));
+    core.info(`Cached binary: ${cachedBin}`);
+    core.info(`Cached binary exists: ${fs.existsSync(cachedBin)}`);
+    await exec.exec("ls", ["-la", path.dirname(cachedBin)], {
+      ignoreReturnCode: true,
+    });
 
     return { root, bin: this.binPath(version) };
   }
@@ -110,6 +142,17 @@ export class MacInstaller implements Installer {
   async test(version: versions.Version): Promise<void> {
     const bin = path.basename(this.binPath(version));
     const msedgeBin = await io.which(bin, true);
-    await exec.exec(`"${msedgeBin}"`, ["--version"]);
+    core.info(`Testing binary: ${msedgeBin}`);
+    const output = await exec.getExecOutput(`"${msedgeBin}"`, ["--version"], {
+      ignoreReturnCode: true,
+    });
+    core.info(`stdout: ${output.stdout}`);
+    core.info(`stderr: ${output.stderr}`);
+    core.info(`exit code: ${output.exitCode}`);
+    if (output.exitCode !== 0) {
+      throw new Error(
+        `Edge binary test failed with exit code ${output.exitCode}\nstderr: ${output.stderr}`,
+      );
+    }
   }
 }

--- a/src/installer_windows.ts
+++ b/src/installer_windows.ts
@@ -101,12 +101,11 @@ export class WindowsInstaller implements Installer {
 
   async test(_version: versions.Version): Promise<void> {
     const msedgeBin = await io.which("msedge", true);
-    await exec.exec("wmic", [
-      "datafile",
-      "where",
-      `name="${msedgeBin.replace(/\\/g, "\\\\")}"`,
-      "get",
-      "version",
+    await exec.exec("powershell", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `(Get-Item (Get-Command '${msedgeBin}').Source).VersionInfo.ProductVersion`,
     ]);
   }
 }


### PR DESCRIPTION
## Problem

This PR fixes two compatibility issues with the latest CI runners:

### Windows (latest runner)

`wmic` is deprecated and removed from Windows 11 / the latest Windows runner. The action used `wmic` to retrieve the installed Edge version, causing failures on the latest Windows runner.

### macOS (latest runner, macOS 15 arm64)

On macOS 15 (arm64), the action failed with `exit code null` when running `Microsoft Edge --version` from the tool cache.

`tc.cacheDir()` uses `copySourceDirectory: false`, which copies the contents of the source directory into the cache root, stripping the `.app` directory name. The cached binary ended up at:

    hostedtoolcache/msedge/stable/arm64/Contents/MacOS/Microsoft Edge

The Edge launcher locates its bundle root two levels up, finding `arm64/` which has no `.app` extension. On macOS 15, Edge validates the bundle path and exits immediately with a signal kill (null exit code, empty stderr).

## Fix

### Windows

Replace `wmic` with `Get-Item` (PowerShell) to retrieve the installed Edge version.

### macOS

Wrap the `.app` bundle in a `wrapper/` subdirectory before calling `tc.cacheDir()`, so the `.app` name is preserved in the cache:

    hostedtoolcache/msedge/stable/arm64/Microsoft Edge.app/Contents/MacOS/Microsoft Edge

Also updated `binPath()` to include the `.app/Contents/MacOS/` path components.

## Verification

All CI jobs pass on macOS (stable, beta, dev, canary), Windows, and Ubuntu.
