### PR TITLE
fix: update Node.js runtime to v24 LTS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   edge-path:
     description: 'The installed Edge path.'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "packageManager": "pnpm@8.7.5",
   "engines": {
-    "node": "20.6.1"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",


### PR DESCRIPTION
Update the Node.js runtime from `node20` to `node24` (latest LTS).

## Changes
- `action.yml`: `runs.using` updated to `node24`
- `package.json`: `engines.node` updated to `>=24.0.0`

Node.js 20 reaches end-of-life on April 30, 2026. Node.js 24 became LTS in October 2025 and is supported until April 2028.